### PR TITLE
Use git repo name as recipe name

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,8 +17,8 @@
 # under the License.
 #
 
-include_recipe 'varnishd::build'
-include_recipe 'varnishd::vmods'
+include_recipe 'chef-varnishd::build'
+include_recipe 'chef-varnishd::vmods'
 
 user node[:varnishd][:runtime][:user] do
   system true

--- a/recipes/vmods.rb
+++ b/recipes/vmods.rb
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-include_recipe 'varnishd::build'
+include_recipe 'chef-varnishd::build'
 include_recipe 'git'
 
 directory node[:varnishd][:runtime][:vmod_dir] do


### PR DESCRIPTION
Using the repo name as the recipe name is the standard - may reduce confusion when users are installing this recipe.
